### PR TITLE
Revert "Wrong 'cd' path before git (#66)"

### DIFF
--- a/docs/update_gcp.md
+++ b/docs/update_gcp.md
@@ -37,7 +37,7 @@ Once this is done, you can access your jupyter notebook at [localhost:8080/tree]
  To update the course repo, go in your terminal and run those two instructions:
 
 ``` bash
-cd tutorials/fastai/course-v3
+cd tutorials/fastai
 git pull
 ```
 


### PR DESCRIPTION
This reverts commit 1e06eb9ae6e8ff6088a2f95b3ca4256547c06719.